### PR TITLE
Add matmul3 examples and CPU ops check

### DIFF
--- a/simulate.py
+++ b/simulate.py
@@ -95,3 +95,13 @@ if __name__ == "__main__":
     matmul(cache2, a, b, c)
     print(cache2)
     print("utilization:", simulator.utilization(cache2))
+    bw = cache2.parent
+    op = bw.cache.parent
+    expected_ops = a.sz[0] * a.sz[1] * b.sz[1]
+    assert op.time == expected_ops
+    print("cpu operations:", op.time)
+
+    import matmul3
+
+    matmul3._run_example(8, 1, 8, 1, "Skinny * Wide * Skinny")
+    matmul3._run_example(8, 4, 4, 8, "Square-ish triple")

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -37,6 +37,15 @@ class TestSimulateMatmul(unittest.TestCase):
         simulate.matmul(L1, A, B, C)
         self.assertEqual(matrix_to_lists(C), matrix_to_lists(B))
 
+    def test_matmul_cpu_operations(self):
+        L1, L0, bw, op = self.make_hierarchy()
+        n, m, k = 2, 3, 4
+        A = L1.calloc(n, m)
+        B = L1.calloc(m, k)
+        C = L1.calloc(n, k)
+        simulate.matmul(L1, A, B, C)
+        self.assertEqual(op.time, n * m * k)
+
     def test_matmul_edge_tiles_non_multiple_of_block(self):
         # This catches edge handling when dimensions are not multiples of 4
         L1, L0, bw, op = self.make_hierarchy(l0_size=2048, l1_size=20000)


### PR DESCRIPTION
## Summary
- run additional matmul3 examples from simulate.py
- assert CPU operation count equals a*b*c
- cover CPU operations in tests

## Testing
- `python -m unittest discover -v`
- `python simulate.py`

------
https://chatgpt.com/codex/tasks/task_e_68b12bab6d84832f9501002e6c1c7381