### PR TITLE
matmul3: display expected operations

### DIFF
--- a/matmul3.py
+++ b/matmul3.py
@@ -90,6 +90,8 @@ def _new_cache(L1_size=100000, L0_size=256):
 
 def _run_example(n, m, p, r, title):
     print(f"\n=== {title}: {n}x{m} * {m}x{p} * {p}x{r} ===")
+    expected_ops = n * m * p + m * p * r
+    print(f"expected ops: {expected_ops}")
 
     # Two-matmul baseline
     cache_two = _new_cache()


### PR DESCRIPTION
## Summary
- print expected operation count `abc+bcd` for triple matrix multiply examples

## Testing
- `python -m unittest discover -v`
- `python - <<'PY'
import matmul3
matmul3._run_example(2, 2, 2, 2, 'tiny')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b130c3d040832f9a733650d1419e52