### PR TITLE
bandwidth: add key metadata helper

### DIFF
--- a/bandwidth_dynamic.py
+++ b/bandwidth_dynamic.py
@@ -20,6 +20,23 @@ def _dp_split_key(key):
     return pairs[:-1], pairs[-1]
 
 
+def _dp_first_input_output_count(key):
+    """Return first input pair, output pair, and input count.
+
+    ``key`` alternates ``(shape, level)`` pairs for each input matrix
+    followed by the output pair. At least two input matrices must be
+    present.
+
+    Returns ``(first_input, output, n_inputs)`` where each element is a
+    ``(shape, level)`` pair.
+    """
+
+    ops, outp = _dp_split_key(key)
+    if len(ops) < 2:
+        raise ValueError("need at least two input matrices")
+    return ops[0], outp, len(ops)
+
+
 def _dp_join_key(ops, outp):
     """Assemble a DP key from operand and output pairs."""
 

--- a/tests/test_bandwidth_dynamic_key_info.py
+++ b/tests/test_bandwidth_dynamic_key_info.py
@@ -1,0 +1,16 @@
+import unittest
+from bandwidth_dynamic import _dp_first_input_output_count
+
+
+class TestFirstInputOutputCount(unittest.TestCase):
+    def test_basic_key(self):
+        key = ((2, 3), 0, (3, 4), 0, (2, 4), 0)
+        first_in, out, n = _dp_first_input_output_count(key)
+        self.assertEqual(first_in, ((2, 3), 0))
+        self.assertEqual(out, ((2, 4), 0))
+        self.assertEqual(n, 2)
+
+    def test_requires_two_inputs(self):
+        key = ((4, 4), 0, (4, 4), 0)
+        with self.assertRaises(ValueError):
+            _dp_first_input_output_count(key)


### PR DESCRIPTION
## Summary
- add `_dp_first_input_output_count` to extract first input, output, and count from DP keys
- test helper for valid and invalid keys

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68b769175ecc832fbf0bf71d94aeec86