### PR TITLE
Use defaultdict for bandwidth key index

### DIFF
--- a/bandwidth_dynamic.py
+++ b/bandwidth_dynamic.py
@@ -1,6 +1,7 @@
 """Helper routines for Bandwidth.dynamic_times."""
 
 import heapq
+from collections import defaultdict
 from itertools import combinations
 
 
@@ -79,8 +80,6 @@ def _dp_record_keyinfo(keyinfo, key):
         short = _dp_first_input_output_count(key)
     except Exception:
         return
-    if short not in keyinfo:
-        keyinfo[short] = set()
     keyinfo[short].add(key)
 
 
@@ -217,7 +216,7 @@ def dynamic_times_impl(bw, nmatmuls, max_cpu):
     base = bw.cache.dynamic_times(nmatmuls, max_cpu)
     prev_level = bw.cache.level
     out = {}
-    keyinfo = {}
+    keyinfo = defaultdict(set)
     for key, v in base.items():
         base_key = tuple(key)
         out[base_key] = v

--- a/tests/test_bandwidth_dynamic_key_index.py
+++ b/tests/test_bandwidth_dynamic_key_index.py
@@ -6,6 +6,8 @@ ROOT = os.path.dirname(os.path.dirname(__file__))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
+from collections import defaultdict
+
 from simulator import Cache, Bandwidth
 from simulate import muladd
 from bandwidth_dynamic import _dp_first_input_output_count
@@ -17,6 +19,7 @@ class TestBandwidthDynamicKeyIndex(unittest.TestCase):
         res = bw.dynamic_times(2, 1000)
         idx = res.get("_key_index")
         self.assertIsNotNone(idx)
+        self.assertIsInstance(idx, defaultdict)
         # Each key should appear in the index under its shortened form
         for k in res:
             if k == "_key_index":


### PR DESCRIPTION
## Summary
- Simplify bandwidth dynamic key index with `defaultdict`
- Verify key index storage type via unit test

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68b7740358b8832f9cd8996b3a39132b