### PR TITLE
bandwidth_dynamic: rename short key helper

### DIFF
--- a/bandwidth_dynamic.py
+++ b/bandwidth_dynamic.py
@@ -20,8 +20,8 @@ def _dp_split_key(key):
     return pairs[:-1], pairs[-1]
 
 
-def _dp_first_input_output_count(key):
-    """Return first input pair, output pair, and input count.
+def _dp_short_key(key):
+    """Return a shortened key of first input pair, output pair, and count.
 
     ``key`` alternates ``(shape, level)`` pairs for each input matrix
     followed by the output pair. At least two input matrices must be
@@ -76,7 +76,7 @@ def _dp_record_keyinfo(keyinfo, key):
     if keyinfo is None:
         return
     try:
-        short = _dp_first_input_output_count(key)
+        short = _dp_short_key(key)
     except Exception:
         return
     if short not in keyinfo:

--- a/tests/test_bandwidth_dynamic_key_index.py
+++ b/tests/test_bandwidth_dynamic_key_index.py
@@ -8,7 +8,7 @@ if ROOT not in sys.path:
 
 from simulator import Cache, Bandwidth
 from simulate import muladd
-from bandwidth_dynamic import _dp_first_input_output_count
+from bandwidth_dynamic import _dp_short_key
 
 
 class TestBandwidthDynamicKeyIndex(unittest.TestCase):
@@ -21,17 +21,17 @@ class TestBandwidthDynamicKeyIndex(unittest.TestCase):
         for k in res:
             if k == "_key_index":
                 continue
-            short = _dp_first_input_output_count(k)
+            short = _dp_short_key(k)
             self.assertIn(k, idx.get(short, set()))
         # Two variants share the same shortened key
         ab_L1 = ((2, 2), 1, (2, 1), 0, (2, 1), 0)
         ab_bc_L1 = ((2, 2), 1, (2, 1), 1, (2, 1), 0)
-        short = _dp_first_input_output_count(ab_L1)
+        short = _dp_short_key(ab_L1)
         self.assertIn(ab_L1, idx[short])
         self.assertIn(ab_bc_L1, idx[short])
         # Expanded key from DBL should also be indexed
         expanded = ((2, 4), 1, (4, 1), 1, (2, 1), 0)
-        short_exp = _dp_first_input_output_count(expanded)
+        short_exp = _dp_short_key(expanded)
         self.assertIn(expanded, idx[short_exp])
 
 

--- a/tests/test_bandwidth_dynamic_key_info.py
+++ b/tests/test_bandwidth_dynamic_key_info.py
@@ -1,11 +1,11 @@
 import unittest
-from bandwidth_dynamic import _dp_first_input_output_count
+from bandwidth_dynamic import _dp_short_key
 
 
-class TestFirstInputOutputCount(unittest.TestCase):
+class TestShortKey(unittest.TestCase):
     def test_basic_key(self):
         key = ((2, 3), 0, (3, 4), 0, (2, 4), 0)
-        first_in, out, n = _dp_first_input_output_count(key)
+        first_in, out, n = _dp_short_key(key)
         self.assertEqual(first_in, ((2, 3), 0))
         self.assertEqual(out, ((2, 4), 0))
         self.assertEqual(n, 2)
@@ -13,4 +13,4 @@ class TestFirstInputOutputCount(unittest.TestCase):
     def test_requires_two_inputs(self):
         key = ((4, 4), 0, (4, 4), 0)
         with self.assertRaises(ValueError):
-            _dp_first_input_output_count(key)
+            _dp_short_key(key)


### PR DESCRIPTION
## Summary
- rename `_dp_first_input_output_count` to `_dp_short_key`
- update tests for new helper name

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68b7745d84cc832fa7103744bb09459c