### PR TITLE
simplify bandwidth short key

### DIFF
--- a/bandwidth_dynamic.py
+++ b/bandwidth_dynamic.py
@@ -22,20 +22,21 @@ def _dp_split_key(key):
 
 
 def _dp_short_key(key):
-    """Return a shortened key of first input pair, output pair, and count.
+    """Return a shortened key of input dimensions and level.
 
     ``key`` alternates ``(shape, level)`` pairs for each input matrix
     followed by the output pair. At least two input matrices must be
     present.
 
-    Returns ``(first_input, output, n_inputs)`` where each element is a
-    ``(shape, level)`` pair.
+    Returns the first input's dimensions followed by its cache level,
+    e.g. ``(m, k, level)``.
     """
 
-    ops, outp = _dp_split_key(key)
+    ops, _ = _dp_split_key(key)
     if len(ops) < 2:
         raise ValueError("need at least two input matrices")
-    return ops[0], outp, len(ops)
+    shp, lvl = ops[0]
+    return (*shp, lvl)
 
 
 def _dp_join_key(ops, outp):

--- a/tests/test_bandwidth_dynamic_key_info.py
+++ b/tests/test_bandwidth_dynamic_key_info.py
@@ -5,10 +5,8 @@ from bandwidth_dynamic import _dp_short_key
 class TestShortKey(unittest.TestCase):
     def test_basic_key(self):
         key = ((2, 3), 0, (3, 4), 0, (2, 4), 0)
-        first_in, out, n = _dp_short_key(key)
-        self.assertEqual(first_in, ((2, 3), 0))
-        self.assertEqual(out, ((2, 4), 0))
-        self.assertEqual(n, 2)
+        short = _dp_short_key(key)
+        self.assertEqual(short, (2, 3, 0))
 
     def test_requires_two_inputs(self):
         key = ((4, 4), 0, (4, 4), 0)


### PR DESCRIPTION
## Summary
- simplify `_dp_short_key` to return only the first input's dimensions and level
- adjust tests for new short key shape

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68b77586566c832f89471a037e004534