### PR TITLE
docs: forbid silent fallbacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Each command runs from the repository root. CI runs the same build and test step
 - Structure: keep functions small and focused; prefer explicit data flow over hidden mutation.
 - Formatting: no enforced tool yet; if used locally, format with `black` (88 cols) and lint with `ruff` before submitting.
 - Types: do not use type annotations or the `typing` module; prefer clear names and brief docstrings/comments.
+- Error handling: avoid silent fallbacks or swallowing exceptions; let unexpected states crash loudly to expose bugs.
 
 ## Testing Guidelines
 - Framework: `unittest` (`unittest.TestCase`).


### PR DESCRIPTION
## Summary
- add guideline to avoid silent fallbacks or exception swallowing so bugs crash loudly

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68b7d24c4c70832f925556d5c56f44f9