### PR TITLE
bandwidth_dynamic: inline key registration

### DIFF
--- a/bandwidth_dynamic.py
+++ b/bandwidth_dynamic.py
@@ -72,19 +72,7 @@ def _dp_bw_time_for_level(bw, key, level_here):
     return words * bw.input_clocks_per_word
 
 
-def _dp_record_keyinfo(keyinfo, key):
-    """Add ``key`` to the shortened-key index mapping."""
-
-    if keyinfo is None:
-        return
-    try:
-        short = _dp_short_key(key)
-    except Exception:
-        return
-    keyinfo[short].add(key)
-
-
-def _dp_update_mapping(mapping, new_key, new_cpu, new_bws, tag, keyinfo=None, heap=None):
+def _dp_update_mapping(mapping, new_key, new_cpu, new_bws, tag, keyinfo, heap=None):
     """Insert or improve a DP entry with computed times and a tag.
 
     ``tag`` is stored verbatim as the first element in the mapping entry.
@@ -97,7 +85,7 @@ def _dp_update_mapping(mapping, new_key, new_cpu, new_bws, tag, keyinfo=None, he
 
     if new_key not in mapping:
         mapping[new_key] = new
-        _dp_record_keyinfo(keyinfo, new_key)
+        keyinfo[_dp_short_key(new_key)].add(new_key)
         if heap is not None:
             heapq.heappush(heap, (new_cpu, new_key))
         return
@@ -108,11 +96,12 @@ def _dp_update_mapping(mapping, new_key, new_cpu, new_bws, tag, keyinfo=None, he
 
     if new_max < cur_max or (new_max == cur_max and sum(new[1:]) < sum(cur[1:])):
         mapping[new_key] = new
+        keyinfo[_dp_short_key(new_key)].add(new_key)
         if heap is not None:
             heapq.heappush(heap, (new_cpu, new_key))
 
 
-def _dp_expand_key(key, times, mapping, level_here, max_cpu_time, heap=None, keyinfo=None):
+def _dp_expand_key(key, times, mapping, level_here, max_cpu_time, keyinfo, heap=None):
     """Attempt DBL expansion for one key.
 
     For each legal position ``j`` where adjacent operands are at
@@ -175,7 +164,7 @@ def _dp_expand_key(key, times, mapping, level_here, max_cpu_time, heap=None, key
         _dp_update_mapping(mapping, new_key, new_cpu, new_bws, ("DBL", j), keyinfo, heap)
 
 
-def _dp_expand(mapping, level_here, max_cpu_time, keyinfo=None):
+def _dp_expand(mapping, level_here, max_cpu_time, keyinfo):
     """Run the bandwidth-level DP expansion over all current entries.
 
     Uses a min-heap ordered by CPU time. While the smallest entry can be
@@ -199,7 +188,7 @@ def _dp_expand(mapping, level_here, max_cpu_time, keyinfo=None):
         cur_cpu = times[1]
         if cur_cpu > max_cpu_time / 2:
             break
-        _dp_expand_key(key, times, mapping, level_here, max_cpu_time, heap, keyinfo)
+        _dp_expand_key(key, times, mapping, level_here, max_cpu_time, keyinfo, heap)
     return mapping
 
 
@@ -261,7 +250,7 @@ def dynamic_times_impl(bw, nmatmuls, max_cpu):
     for key, v in base.items():
         base_key = tuple(key)
         out[base_key] = v
-        _dp_record_keyinfo(keyinfo, base_key)
+        keyinfo[_dp_short_key(base_key)].add(base_key)
         candidate_idxs = []
         for i in range(0, len(key), 2):
             lvl = key[i + 1]
@@ -280,7 +269,7 @@ def dynamic_times_impl(bw, nmatmuls, max_cpu):
                 last_op = ("LDST",) + tuple(pair_idxs)
                 new_key = tuple(kl)
                 out[new_key] = [last_op] + v[1:] + [bw_time]
-                _dp_record_keyinfo(keyinfo, new_key)
+                keyinfo[_dp_short_key(new_key)].add(new_key)
     _dp_expand(out, prev_level + 1, max_cpu, keyinfo)
     out["_key_index"] = keyinfo
     return out

--- a/tests/test_bandwidth_join_short_keys.py
+++ b/tests/test_bandwidth_join_short_keys.py
@@ -7,7 +7,7 @@ ROOT = os.path.dirname(os.path.dirname(__file__))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
-from bandwidth_dynamic import _dp_join_short_keys, _dp_record_keyinfo
+from bandwidth_dynamic import _dp_join_short_keys, _dp_short_key
 
 
 class TestBandwidthJoinShortKeys(unittest.TestCase):
@@ -31,8 +31,8 @@ class TestBandwidthJoinShortKeys(unittest.TestCase):
     def test_join_short_keys_adds_entry_within_limits(self):
         mapping = {self.key1: self.value1, self.key2: self.value2}
         keyinfo = defaultdict(set)
-        _dp_record_keyinfo(keyinfo, self.key1)
-        _dp_record_keyinfo(keyinfo, self.key2)
+        keyinfo[_dp_short_key(self.key1)].add(self.key1)
+        keyinfo[_dp_short_key(self.key2)].add(self.key2)
         heap = []
 
         _dp_join_short_keys(self.key1, keyinfo, mapping, heap, 4, 20)
@@ -43,8 +43,8 @@ class TestBandwidthJoinShortKeys(unittest.TestCase):
     def test_join_short_keys_respects_cpu_limit(self):
         mapping = {self.key1: self.value1, self.key2: self.value2}
         keyinfo = defaultdict(set)
-        _dp_record_keyinfo(keyinfo, self.key1)
-        _dp_record_keyinfo(keyinfo, self.key2)
+        keyinfo[_dp_short_key(self.key1)].add(self.key1)
+        keyinfo[_dp_short_key(self.key2)].add(self.key2)
         heap = []
 
         _dp_join_short_keys(self.key1, keyinfo, mapping, heap, 4, 16)


### PR DESCRIPTION
## Summary
- drop `_dp_record_keyinfo` and register keys inline
- update `_dp_update_mapping` and tests to use `_dp_short_key` directly

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68b7d8d9a13c832fa1e4e78afa4c44bc