### PR TITLE
bandwidth_dynamic: rename join_short_keys to join_matmuls

### DIFF
--- a/bandwidth_dynamic.py
+++ b/bandwidth_dynamic.py
@@ -7,7 +7,7 @@ from itertools import combinations, zip_longest
 
 # Toggle DP join of matmul chains. Disabled by default until upstream code
 # is ready to handle "JOIN" entries.
-ENABLE_DP_JOIN_SHORT_KEYS = False
+ENABLE_DP_JOIN_MATMULS = False
 
 
 def _shape_elems(shape):
@@ -193,8 +193,8 @@ def _dp_expand(mapping, level_here, max_cpu_time, keyinfo=None):
     return mapping
 
 
-def _dp_join_short_keys(key, keyinfo, mapping, heap, maxn, max_cpu_time):
-    """Join ``key`` with other keys sharing its output short key.
+def _dp_join_matmuls(key, keyinfo, mapping, heap, maxn, max_cpu_time):
+    """Join ``key`` with other matmul chains sharing its output short key.
 
     ``keyinfo`` maps short keys to full keys. Using the output dimensions and
     level of ``key`` we look up candidate keys whose first operand matches.
@@ -270,7 +270,7 @@ def dynamic_times_impl(bw, nmatmuls, max_cpu):
                 keyinfo[_dp_short_key(new_key)].add(new_key)
     _dp_expand(out, prev_level + 1, max_cpu, keyinfo)
 
-    if ENABLE_DP_JOIN_SHORT_KEYS:
+    if ENABLE_DP_JOIN_MATMULS:
         heap = []
         for key, times in out.items():
             cpu = times[1]
@@ -280,7 +280,7 @@ def dynamic_times_impl(bw, nmatmuls, max_cpu):
             times = out.get(key)
             if times is None:
                 continue
-            _dp_join_short_keys(key, keyinfo, out, heap, nmatmuls, max_cpu)
+            _dp_join_matmuls(key, keyinfo, out, heap, nmatmuls, max_cpu)
 
     out["_key_index"] = keyinfo
     return out

--- a/tests/test_bandwidth_dynamic_join_matmuls.py
+++ b/tests/test_bandwidth_dynamic_join_matmuls.py
@@ -11,15 +11,15 @@ from simulate import muladd
 import bandwidth_dynamic
 
 
-class TestBandwidthDynamicJoinShortKeys(unittest.TestCase):
+class TestBandwidthDynamicJoinMatmuls(unittest.TestCase):
     def test_join_entries_present_when_enabled(self):
-        flag = bandwidth_dynamic.ENABLE_DP_JOIN_SHORT_KEYS
-        bandwidth_dynamic.ENABLE_DP_JOIN_SHORT_KEYS = True
+        flag = bandwidth_dynamic.ENABLE_DP_JOIN_MATMULS
+        bandwidth_dynamic.ENABLE_DP_JOIN_MATMULS = True
         try:
             bw = Bandwidth(Cache(12, muladd))
             res = bw.dynamic_times(3, 20)
         finally:
-            bandwidth_dynamic.ENABLE_DP_JOIN_SHORT_KEYS = flag
+            bandwidth_dynamic.ENABLE_DP_JOIN_MATMULS = flag
         found = False
         for v in res.values():
             if isinstance(v, list) and v and isinstance(v[0], tuple) and v[0][0] == "JOIN":

--- a/tests/test_bandwidth_join_dp_matmuls.py
+++ b/tests/test_bandwidth_join_dp_matmuls.py
@@ -7,10 +7,10 @@ ROOT = os.path.dirname(os.path.dirname(__file__))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
-from bandwidth_dynamic import _dp_join_short_keys, _dp_short_key
+from bandwidth_dynamic import _dp_join_matmuls, _dp_short_key
 
 
-class TestBandwidthJoinShortKeys(unittest.TestCase):
+class TestBandwidthJoinMatmuls(unittest.TestCase):
     def setUp(self):
         self.key1 = ((2, 3), 0, (3, 4), 0, (2, 4), 0)
         self.value1 = [("LDST", 0), 10, 5]
@@ -28,26 +28,26 @@ class TestBandwidthJoinShortKeys(unittest.TestCase):
         )
         self.expect_value = [("JOIN", 2), 17, 5]
 
-    def test_join_short_keys_adds_entry_within_limits(self):
+    def test_join_matmuls_adds_entry_within_limits(self):
         mapping = {self.key1: self.value1, self.key2: self.value2}
         keyinfo = defaultdict(set)
         keyinfo[_dp_short_key(self.key1)].add(self.key1)
         keyinfo[_dp_short_key(self.key2)].add(self.key2)
         heap = []
 
-        _dp_join_short_keys(self.key1, keyinfo, mapping, heap, 4, 20)
+        _dp_join_matmuls(self.key1, keyinfo, mapping, heap, 4, 20)
 
         self.assertEqual(mapping[self.joined_key], self.expect_value)
         self.assertIn((17, self.joined_key), heap)
 
-    def test_join_short_keys_respects_cpu_limit(self):
+    def test_join_matmuls_respects_cpu_limit(self):
         mapping = {self.key1: self.value1, self.key2: self.value2}
         keyinfo = defaultdict(set)
         keyinfo[_dp_short_key(self.key1)].add(self.key1)
         keyinfo[_dp_short_key(self.key2)].add(self.key2)
         heap = []
 
-        _dp_join_short_keys(self.key1, keyinfo, mapping, heap, 4, 16)
+        _dp_join_matmuls(self.key1, keyinfo, mapping, heap, 4, 16)
 
         self.assertNotIn(self.joined_key, mapping)
         self.assertEqual(heap, [])


### PR DESCRIPTION
## Summary
- rename DP helper `_dp_join_short_keys` to `_dp_join_matmuls`
- update flag to `ENABLE_DP_JOIN_MATMULS`
- adjust tests for new names

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68b7f88fbb18832fb08277484161076a