### PR TITLE
deps: include pytest in project requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "Simulator for optimal kernels with cache and bandwidth constraints."
 readme = "README.md"
 requires-python = ">=3.9"
+dependencies = ["pytest"]
 license = { file = "LICENSE" }
 keywords = ["simulation", "tensor", "matrix", "performance", "kernels"]
 classifiers = [


### PR DESCRIPTION
## Summary
- ensure pytest is installed by default so test modules import correctly

## Testing
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68b80572b24c832f96082d5f7bd2664e