### PR TITLE
dynamic: handle JOIN matmul chains

### DIFF
--- a/dynamic.py
+++ b/dynamic.py
@@ -175,6 +175,8 @@ def run_dynamic(results, node, *tensors, out_level=None, reset_counter=True, acc
         out = _run_dynamic_binopx(node, tensors, accumulate_output, only_store=only_store)
     elif entry[0][0] == "LDST":
         out = _run_dynamic_ldst(node, tensors, accumulate_output, entry[0][1:], out_level=out_level, key=key, results=results, only_store=only_store)
+    elif entry[0][0] == "JOIN":
+        out = _run_dynamic_join(node, tensors, accumulate_output, entry[0][1], out_level=out_level, key=key, results=results, only_store=only_store)
     elif entry[0][0] == "DBL":
         out = _run_dynamic_dbl(node, tensors, accumulate_output, entry[0][1], out_level=out_level, key=key, results=results, only_store=only_store)
     else:
@@ -412,6 +414,48 @@ def _run_dynamic_dbl(node, tensors, accumulate_output, j, out_level=None, key=No
         else:
             run_dynamic(results, node, *ops1, reset_counter=False, accumulate_output=out, out_level=out_level, only_store=only_store)
         run_dynamic(results, node, *ops2, reset_counter=False, accumulate_output=out, out_level=out_level, only_store=False)
+
+    return out
+
+
+def _run_dynamic_join(node, tensors, accumulate_output, n_inputs, out_level=None, key=None, results=None, only_store=False):
+    """Execute a JOIN step by concatenating two matmul chains.
+
+    ``n_inputs`` specifies how many operands belong to the first chain. We
+    first run that subproblem without an explicit output. The resulting
+    intermediate matrix is then used as the leading operand of the second
+    chain, which runs with ``accumulate_output`` if provided.
+    """
+
+    if n_inputs < 1 or n_inputs >= len(tensors):
+        raise ValueError("JOIN split out of range")
+
+    # First subchain: compute the left part to obtain the intermediate result.
+    ops1 = list(tensors[:n_inputs])
+    interm_level = getattr(tensors[n_inputs - 1], "level", 0)
+    interm = run_dynamic(
+        results,
+        node,
+        *ops1,
+        reset_counter=False,
+        out_level=interm_level,
+        only_store=only_store or accumulate_output is None,
+    )
+
+    # Second subchain: use the intermediate result as the first operand.
+    ops2 = [interm] + list(tensors[n_inputs:])
+    out = run_dynamic(
+        results,
+        node,
+        *ops2,
+        reset_counter=False,
+        accumulate_output=accumulate_output,
+        out_level=out_level,
+        only_store=only_store,
+    )
+
+    if isinstance(node, Cache) or isinstance(node, Bandwidth):
+        node.free(interm, allow_lower_level=True)
 
     return out
 

--- a/tests/test_run_dynamic_join_matmuls.py
+++ b/tests/test_run_dynamic_join_matmuls.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from simulator import Cache, Bandwidth, Tensor
+from simulate import muladd
+from dynamic import run_dynamic
+import bandwidth_dynamic
+
+
+class TestRunDynamicJoinMatmuls(unittest.TestCase):
+    def test_run_dynamic_handles_join_entries(self):
+        flag = bandwidth_dynamic.ENABLE_DP_JOIN_MATMULS
+        bandwidth_dynamic.ENABLE_DP_JOIN_MATMULS = True
+        try:
+            bw = Bandwidth(Cache(12, muladd))
+            results = bw.dynamic_times(3, 20)
+            join_key = None
+            for k, v in results.items():
+                if isinstance(v, list) and v and isinstance(v[0], tuple) and v[0][0] == "JOIN":
+                    join_key = k
+                    break
+            self.assertIsNotNone(join_key)
+
+            pairs = [(join_key[i], join_key[i + 1]) for i in range(0, len(join_key), 2)]
+            ops = pairs[:-1]
+            out_dims, out_level = pairs[-1]
+
+            tensors = [Tensor.zeros(shp[0], shp[1], level=lvl) for shp, lvl in ops]
+            tensors = [bw.alloc(t, allow_lower_level=True) for t in tensors]
+
+            out = run_dynamic(results, bw, *tensors, out_level=out_level, reset_counter=True)
+            self.assertEqual(out.sz, [out_dims[0], out_dims[1]])
+            bw.free(out, allow_lower_level=True)
+            for t in tensors:
+                bw.free(t, allow_lower_level=True)
+        finally:
+            bandwidth_dynamic.ENABLE_DP_JOIN_MATMULS = flag
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- execute JOIN entries in the dynamic runner via recursive subcalls
- cover JOIN handling with a new unit test

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68b804a2dba8832fa16d092747fbc817