### PR TITLE
Enable DP join matmul chains by default

### DIFF
--- a/bandwidth_dynamic.py
+++ b/bandwidth_dynamic.py
@@ -5,9 +5,8 @@ from collections import defaultdict
 from itertools import combinations, zip_longest
 
 
-# Toggle DP join of matmul chains. Disabled by default until upstream code
-# is ready to handle "JOIN" entries.
-ENABLE_DP_JOIN_MATMULS = False
+# Toggle DP join of matmul chains. Enabled by default to allow "JOIN" entries.
+ENABLE_DP_JOIN_MATMULS = True
 
 
 def _shape_elems(shape):


### PR DESCRIPTION
## Summary
- default ENABLE_DP_JOIN_MATMULS to True so dynamic programming can emit JOIN entries

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68b808441874832f869d946cc08368ca