### PR TITLE
docs: drop unittest verbose instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,6 @@
 ## Build, Test, and Development Commands
 - Install (editable): `python -m pip install -e .`
 - Build sdist/wheel: `python -m pip install build && python -m build`
-- Run tests (verbose): `python -m unittest discover -v`
 - Run tests (pytest): `pytest`
 - Run examples locally: `python simulate.py`
 


### PR DESCRIPTION
## Summary
- remove redundant unittest command from AGENTS guidelines

## Testing
- `python -m unittest discover -v`
- `pytest` *(fails: previous_key missing for ((1, 1), 0, (1, 1), 0, (1, 8), 1, (1, 8), 1) with op ('JOIN', 2) -> None)*
- `pytest -k "not run_dynamic_all_entries" -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8a9dc305c832fa6b2a8179b04e25e