### PR TITLE
dynamic: add JOIN predecessor lookup

### DIFF
--- a/bandwidth_dynamic.py
+++ b/bandwidth_dynamic.py
@@ -177,6 +177,10 @@ def _dp_expand(mapping, level_here, max_cpu_time, keyinfo=None):
 
     heap = []
     for key, times in mapping.items():
+        # Skip bookkeeping entries such as "_key_index" or malformed rows
+        # that do not follow the [tag, cpu, bw...] layout.
+        if key == "_key_index" or not isinstance(times, list) or len(times) < 2:
+            continue
         cpu = times[1]
         heapq.heappush(heap, (cpu, key))
 
@@ -272,6 +276,8 @@ def dynamic_times_impl(bw, nmatmuls, max_cpu):
     if ENABLE_DP_JOIN_MATMULS:
         heap = []
         for key, times in out.items():
+            if key == "_key_index" or not isinstance(times, list) or len(times) < 2:
+                continue
             cpu = times[1]
             heapq.heappush(heap, (cpu, key))
         while heap:

--- a/dynamic.py
+++ b/dynamic.py
@@ -510,6 +510,23 @@ def previous_key(key, op=None):
                         flat.extend([shp, lvl])
                     flat.extend([new_out[0], new_out[1]])
                     return tuple(flat)
+        if kind == "JOIN":
+            # Reconstruct the first subproblem that produced this JOIN entry.
+            try:
+                n_inputs = op[1]
+            except Exception:
+                n_inputs = None
+            if isinstance(n_inputs, int) and 0 < n_inputs <= len(ops):
+                first_ops = ops[:n_inputs]
+                # Output dims: rows from first operand, cols from last operand
+                out_rows = first_ops[0][0][0]
+                out_cols = first_ops[-1][0][1]
+                out_lvl = first_ops[-1][1]
+                flat = []
+                for shp, lvl in first_ops:
+                    flat.extend([shp, lvl])
+                flat.extend([(out_rows, out_cols), out_lvl])
+                return tuple(flat)
     return None
 
 


### PR DESCRIPTION
## Summary
- support JOIN operations in previous_key
- guard bandwidth DP expansion against bookkeeping entries

## Testing
- `pytest -q` *(fails: AssertionError in test_run_dynamic_for_all_muladd_dynamic_times_three_cache)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a9fa7ab8832f8e94f49d82dd37a0