### PR TITLE
dynamic: track join intermediate level

### DIFF
--- a/bandwidth_dynamic.py
+++ b/bandwidth_dynamic.py
@@ -305,11 +305,12 @@ def join_matmuls(key1, value1, key2, value2):
 
     joined_key = key1[:-2] + key2[2:]
     n_inputs = len(key1) // 2 - 1
+    interm_level = key1[-1]
 
     counters = []
     for a, b in zip_longest(value1[1:], value2[1:], fillvalue=0):
         counters.append(a + b)
 
-    joined_value = [("JOIN", n_inputs)] + counters
+    joined_value = [("JOIN", n_inputs, interm_level)] + counters
     return joined_key, joined_value
 

--- a/dynamic.py
+++ b/dynamic.py
@@ -514,14 +514,16 @@ def previous_key(key, op=None):
             # Reconstruct the first subproblem that produced this JOIN entry.
             try:
                 n_inputs = op[1]
+                interm_lvl = op[2]
             except Exception:
                 n_inputs = None
+                interm_lvl = None
             if isinstance(n_inputs, int) and 0 < n_inputs <= len(ops):
                 first_ops = ops[:n_inputs]
                 # Output dims: rows from first operand, cols from last operand
                 out_rows = first_ops[0][0][0]
                 out_cols = first_ops[-1][0][1]
-                out_lvl = first_ops[-1][1]
+                out_lvl = interm_lvl if isinstance(interm_lvl, int) else first_ops[-1][1]
                 flat = []
                 for shp, lvl in first_ops:
                     flat.extend([shp, lvl])
@@ -545,15 +547,17 @@ def previous_key2(key, op=None):
     if isinstance(op, tuple) and op and op[0] == "JOIN":
         try:
             n_inputs = op[1]
+            interm_lvl = op[2]
         except Exception:
             n_inputs = None
+            interm_lvl = None
         if isinstance(n_inputs, int) and 0 < n_inputs < len(ops):
             left_ops = ops[:n_inputs]
             right_ops = ops[n_inputs:]
             # Build intermediate result from the left subchain
             interm_rows = left_ops[0][0][0]
             interm_cols = left_ops[-1][0][1]
-            interm_lvl = left_ops[-1][1]
+            interm_lvl = interm_lvl if isinstance(interm_lvl, int) else left_ops[-1][1]
             chain = [((interm_rows, interm_cols), interm_lvl)] + list(right_ops)
             flat = []
             for shp, lvl in chain:

--- a/tests/test_bandwidth_join_dp_matmuls.py
+++ b/tests/test_bandwidth_join_dp_matmuls.py
@@ -26,7 +26,7 @@ class TestBandwidthJoinMatmuls(unittest.TestCase):
             (2, 5),
             0,
         )
-        self.expect_value = [("JOIN", 2), 17, 5]
+        self.expect_value = [("JOIN", 2, 0), 17, 5]
 
     def test_join_matmuls_adds_entry_within_limits(self):
         mapping = {self.key1: self.value1, self.key2: self.value2}

--- a/tests/test_bandwidth_join_matmuls.py
+++ b/tests/test_bandwidth_join_matmuls.py
@@ -19,7 +19,7 @@ class TestBandwidthJoinMatmuls(unittest.TestCase):
         joined_key, joined_value = join_matmuls(key1, value1, key2, value2)
 
         expect_key = ((2, 3), 0, (3, 4), 0, (4, 5), 0, (2, 5), 0)
-        expect_value = [("JOIN", 2), 17, 5]
+        expect_value = [("JOIN", 2, 0), 17, 5]
         self.assertEqual(joined_key, expect_key)
         self.assertEqual(joined_value, expect_value)
 


### PR DESCRIPTION
## Summary
- include intermediate output level in JOIN tags
- account for new join tag layout in previous_key helpers
- adjust tests for updated JOIN tag

## Testing
- `pytest` (fails: AssertionError in run_dynamic_all_entries tests)

------
https://chatgpt.com/codex/tasks/task_e_68b8b2a081f0832facffc4caf329192c